### PR TITLE
Enable run-script for running latest rust-optimizer version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ library = []
 optimize = """docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.0
+  cosmwasm/rust-optimizer:0.12.3
 """
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,13 @@ backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 
+[package.metadata.scripts]
+optimize = """docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.12.0
+"""
+
 [dependencies]
 cosmwasm-std = { version = "0.16.2" }
 cosmwasm-storage = { version = "0.16.0" }

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Assuming you have a recent version of rust and cargo (v1.51.0+) installed
 (via [rustup](https://rustup.rs/)),
 then the following should get you a new repo to start a contract:
 
-First, install
-[cargo-generate](https://github.com/ashleygwilliams/cargo-generate).
+
+Install [cargo-generate](https://github.com/ashleygwilliams/cargo-generate) and cargo-run-script.
 Unless you did that before, run this line now:
 
 ```sh
-cargo install cargo-generate --features vendored-openssl
+cargo install cargo-generate cargo-run-script --features vendored-openssl 
 ```
 
 Now, use it to create your new contract.


### PR DESCRIPTION
After the PR:
```shell
cargo run-script optimize
```
Will run:
```shell
docker run --rm -v "$(pwd)":/code \
  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
  cosmwasm/rust-optimizer:0.12.0
```