### PR TITLE
Add minimal option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,14 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-schema = "1.1.2"
-cosmwasm-std = "1.1.2"
-cosmwasm-storage = "1.1.2"
-cw-storage-plus = "0.13.2"
-cw2 = "0.13.2"
-schemars = "0.8.8"
-serde = { version = "1.0.137", default-features = false, features = ["derive"] }
+cosmwasm-schema = "1.1.3"
+cosmwasm-std = "1.1.3"
+cosmwasm-storage = "1.1.3"
+cw-storage-plus = "0.15.1"
+cw2 = "0.15.1"
+schemars = "0.8.10"
+serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 
 [dev-dependencies]
-cw-multi-test = "0.13.2"
+cw-multi-test = "0.15.1"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cargo generate --git https://github.com/CosmWasm/cw-template.git --name PROJECT_
 For cloning minimal code repo:
 
 ```sh
-cargo generate --git https://github.com/CosmWasm/cw-template.git --branch 1.0-minimal --name PROJECT_NAME
+cargo generate --git https://github.com/CosmWasm/cw-template.git --name PROJECT_NAME -d minimal=true
 ```
 
 **Older Version**

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -3,3 +3,17 @@
 # This is needed when files contains curly brackets as in `v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}`.
 # The files will be copied 1:1 to the target project. To avoid shipping them completely add them to `.genignore`.
 exclude = [".circleci/config.yml"]
+
+[placeholders.minimal]
+type = "bool"
+prompt = "Would you like to generate the minimal template?"
+default = false
+
+[conditional.'minimal']
+ignore = [
+    "Developing.md",
+    "Importing.md",
+    "Publishing.md",
+    ".gitpod.yml",
+    ".gitpod.Dockerfile",
+]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -6,7 +6,9 @@ exclude = [".circleci/config.yml"]
 
 [placeholders.minimal]
 type = "bool"
-prompt = "Would you like to generate the minimal template?"
+prompt = """Would you like to generate the minimal template?
+The full template includes some example logic in case you're new to CosmWasm smart contracts.
+The minimal template assumes you already know how to write your own logic, and doesn't get in your way."""
 default = false
 
 [conditional.'minimal']

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -16,4 +16,5 @@ ignore = [
     "Publishing.md",
     ".gitpod.yml",
     ".gitpod.Dockerfile",
+    "src/integration_tests.rs",
 ]

--- a/meta/appveyor.yml
+++ b/meta/appveyor.yml
@@ -39,7 +39,19 @@ build_script:
   # cargo generate.
   - git branch current-ci-checkout
   - cd ..
-  - cargo generate --git cw-template --name testgen-ci --branch current-ci-checkout
+  # Generate minimal
+  - cargo generate --git cw-template --name testgen-ci --branch current-ci-checkout -d minimal=true
+  - cd testgen-ci
+  - ls -lA
+  - cargo fmt -- --check
+  - cargo unit-test
+  - cargo wasm
+  - cargo schema
+  # Cleanup
+  - cd ..
+  - rm -r testgen-ci
+  # Generate full
+  - cargo generate --git cw-template --name testgen-ci --branch current-ci-checkout -d minimal=false
   - cd testgen-ci
   - ls -lA
   - cargo fmt -- --check

--- a/meta/test_generate.sh
+++ b/meta/test_generate.sh
@@ -11,10 +11,8 @@ PROJECT_NAME="testgen-local"
   echo "Navigating to $TMP_DIR"
   cd "$TMP_DIR"
 
-  GIT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current)
-
-  echo "Generating project from local repository (branch $GIT_BRANCH) ..."
-  cargo generate --git "$REPO_ROOT" --name "$PROJECT_NAME" --branch "$GIT_BRANCH"
+  echo "Generating project from local repository ..."
+  cargo generate --path "$REPO_ROOT" --name "$PROJECT_NAME"
 
   (
     cd "$PROJECT_NAME"

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,24 +1,24 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
-use cw2::set_contract_version;
+use cosmwasm_std::{% raw %}{{% endraw %}{% unless minimal %}to_binary, {% endunless %}Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+{% if minimal %}// {% endif %}use cw2::set_contract_version;
 
 use crate::error::ContractError;
-use crate::msg::{ExecuteMsg, GetCountResponse, InstantiateMsg, QueryMsg};
-use crate::state::{State, STATE};
-
+use crate::msg::{ExecuteMsg, {% unless minimal %}GetCountResponse, {% endunless %}InstantiateMsg, QueryMsg};
+{% unless minimal %}use crate::state::{State, STATE};
+{% endunless %}
 {% if minimal %}/*
 {% endif %}// version info for migration info
 const CONTRACT_NAME: &str = "crates.io:{{project-name}}";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
-{% if minimal %}*/{% endif %}
-
+{% if minimal %}*/
+{% endif %}
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
-    deps: DepsMut,
+    {% if minimal %}_{% endif %}deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
-    msg: InstantiateMsg,
+    {% if minimal %}_{% endif %}info: MessageInfo,
+    {% if minimal %}_{% endif %}msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     {% if minimal %}unimplemented!(){% else %}let state = State {
         count: msg.count,
@@ -35,16 +35,16 @@ pub fn instantiate(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
-    deps: DepsMut,
+    {% if minimal %}_{% endif %}deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
-    msg: ExecuteMsg,
+    {% if minimal %}_{% endif %}info: MessageInfo,
+    {% if minimal %}_{% endif %}msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
-    match msg {
+    {% if minimal %}unimplemented!(){% else %}match msg {
         ExecuteMsg::Increment {} => execute::increment(deps),
         ExecuteMsg::Reset { count } => execute::reset(deps, info, count),
-    }
-}
+    }{% endif %}
+}{% unless minimal %}
 
 pub mod execute {
     use super::*;
@@ -68,14 +68,14 @@ pub mod execute {
         })?;
         Ok(Response::new().add_attribute("action", "reset"))
     }
-}
+}{% endunless %}
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
-    match msg {
+pub fn query({% if minimal %}_{% endif %}deps: Deps, _env: Env, {% if minimal %}_{% endif %}msg: QueryMsg) -> StdResult<Binary> {
+    {% if minimal %}unimplemented!(){% else %}match msg {
         QueryMsg::GetCount {} => to_binary(&query::count(deps)?),
-    }
-}
+    }{% endif %}
+}{% unless minimal %}
 
 pub mod query {
     use super::*;
@@ -84,10 +84,10 @@ pub mod query {
         let state = STATE.load(deps.storage)?;
         Ok(GetCountResponse { count: state.count })
     }
-}
+}{% endunless %}
 
 #[cfg(test)]
-mod tests {
+mod tests {% raw %}{{% endraw %}{% unless minimal %}
     use super::*;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{coins, from_binary};
@@ -155,4 +155,4 @@ mod tests {
         let value: GetCountResponse = from_binary(&res).unwrap();
         assert_eq!(5, value.count);
     }
-}
+{% endunless %}}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -7,9 +7,11 @@ use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, GetCountResponse, InstantiateMsg, QueryMsg};
 use crate::state::{State, STATE};
 
-// version info for migration info
+{% if minimal %}/*
+{% endif %}// version info for migration info
 const CONTRACT_NAME: &str = "crates.io:{{project-name}}";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+{% if minimal %}*/{% endif %}
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -18,7 +20,7 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    let state = State {
+    {% if minimal %}unimplemented!(){% else %}let state = State {
         count: msg.count,
         owner: info.sender.clone(),
     };
@@ -28,7 +30,7 @@ pub fn instantiate(
     Ok(Response::new()
         .add_attribute("method", "instantiate")
         .add_attribute("owner", info.sender)
-        .add_attribute("count", msg.count.to_string()))
+        .add_attribute("count", msg.count.to_string())){% endif %}
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,9 +8,6 @@ pub enum ContractError {
 
     #[error("Unauthorized")]
     Unauthorized {},
-
-    #[error("Custom Error val: {val:?}")]
-    CustomError { val: String },
     // Add any other custom errors you like here.
     // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,11 +1,11 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{
+{% if minimal %}use cosmwasm_std::{to_binary, Addr, CosmosMsg, StdResult, WasmMsg};{% else %}use cosmwasm_std::{
     to_binary, Addr, CosmosMsg, CustomQuery, Querier, QuerierWrapper, StdResult, WasmMsg, WasmQuery,
-};
+};{% endif %}
 
-use crate::msg::{ExecuteMsg, GetCountResponse, QueryMsg};
+{% if minimal %}use crate::msg::ExecuteMsg;{% else %}use crate::msg::{ExecuteMsg, GetCountResponse, QueryMsg};{% endif %}
 
 /// CwTemplateContract is a wrapper around Addr that provides a lot of helpers
 /// for working with this.
@@ -25,7 +25,7 @@ impl CwTemplateContract {
             funds: vec![],
         }
         .into())
-    }
+    }{% unless minimal %}
 
     /// Get Count
     pub fn count<Q, T, CQ>(&self, querier: &Q) -> StdResult<GetCountResponse>
@@ -42,5 +42,5 @@ impl CwTemplateContract {
         .into();
         let res: GetCountResponse = QuerierWrapper::<CQ>::new(querier).query(&query)?;
         Ok(res)
-    }
+    }{% endunless %}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod contract;
 mod error;
 pub mod helpers;
-pub mod integration_tests;
-pub mod msg;
+{% unless minimal %}pub mod integration_tests;
+{% endunless %}pub mod msg;
 pub mod state;
 
 pub use crate::error::ContractError;

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,26 +1,27 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 
 #[cw_serde]
-pub struct InstantiateMsg {
+pub struct InstantiateMsg {% raw %}{{% endraw %}{% unless minimal %}
     pub count: i32,
-}
+{% endunless %}}
 
 #[cw_serde]
-pub enum ExecuteMsg {
+pub enum ExecuteMsg {% raw %}{{% endraw %}{% unless minimal %}
     Increment {},
     Reset { count: i32 },
-}
+{% endunless %}}
 
 #[cw_serde]
 #[derive(QueryResponses)]
-pub enum QueryMsg {
+pub enum QueryMsg {% raw %}{{% endraw %}{% unless minimal %}
     // GetCount returns the current count as a json-encoded number
     #[returns(GetCountResponse)]
     GetCount {},
-}
-
+{% endunless %}}
+{% unless minimal %}
 // We define a custom struct for each query response
 #[cw_serde]
 pub struct GetCountResponse {
     pub count: i32,
 }
+{% endunless %}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use schemars::JsonSchema;
+{% unless minimal %}use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::Addr;
@@ -10,4 +10,4 @@ pub struct State {
     pub owner: Addr,
 }
 
-pub const STATE: Item<State> = Item::new("state");
+pub const STATE: Item<State> = Item::new("state");{% endunless %}


### PR DESCRIPTION
closes #96 
A default value can be provided in [different ways](https://cargo-generate.github.io/cargo-generate/templates/custom_placeholders.html#default-values-for-placeholders), most importantly with `-d minimal=true`.
If none is provided it will prompt interactively (selecting `false` by default).

The actual code has mostly the same changes as the `1.0-minimal` branch, but I also removed the `CustomMsg`s and response, as well as the example state. If you think we need them in the minimal version, I can add them too, but I think whoever uses the minimal version, probably already knows how the storage and messages work.

Also changed the appveyor script to build both minimal and full version.