### PR TITLE
update-wasm-version

### DIFF
--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.58.1
+          toolchain: 1.60.0
           target: wasm32-unknown-unknown
           override: true
 
@@ -48,7 +48,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.58.1
+          toolchain: 1.60.0
           override: true
           components: rustfmt, clippy
 


### PR DESCRIPTION
Problem:
Was noticing that when using this package to generate smart-contract repos that the old version would get an error for GH Actions (v1.58.1). 

Solution:
Upgrading that version to 1.60.0 fixes it.

Related:
- https://github.com/CosmWasm/cosmwasm/commit/49ff9fb098f8915b14ba8044b2321423daf128c5#commitcomment-94007845

Looks like we updated across other GH-action commits.