### PR TITLE
Updated Developing.md Rust-Optimizer Docker Versions

### DIFF
--- a/Developing.md
+++ b/Developing.md
@@ -74,7 +74,7 @@ to run it is this:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.6
+  cosmwasm/rust-optimizer:0.12.11
 ```
 
 Or, If you're on an arm64 machine, you should use a docker image built with arm64.
@@ -82,7 +82,7 @@ Or, If you're on an arm64 machine, you should use a docker image built with arm6
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer-arm64:0.12.6
+  cosmwasm/rust-optimizer-arm64:0.12.11
 ```
 
 We must mount the contract code to `/code`. You can use a absolute path instead


### PR DESCRIPTION
Because Using the Rust-Optimizer 0.12.6 was giving me problems 😢  

Using the latest version solves this problem below 🤧

````
error: can't compile schema generator for the wasm32 arch
       hint: are you trying to compile a smart contract without specifying --lib?
  --> src/bin/schema.rs:6:5
   |
6  | /     writeapi! {
7  | |         instantiate: InstantiateMsg,
8  | |         execute: ExecuteMsg,
9  | |         query: QueryMsg,
10 | |     }
   | |__^
   |
   = note: this error originates in the macro write_api (in Nightly builds, run with -Z macro-backtrace for more info)
````