### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
     executor: builder
     steps:
       - checkout
-      - setup_remote_docker
-        docker_layer_caching: true
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Build Docker artifact
           command: docker build --pull -t "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" .
@@ -29,8 +29,8 @@ jobs:
     executor: builder
     steps:
       - checkout
-      - setup_remote_docker
-        docker_layer_caching: true
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Push application Docker image to docker hub
           command: |


### PR DESCRIPTION
got some errors while commiting
`Invalid child element in a block sequence`
https://circleci.com/docs/configuration-reference#checkout Special step used to check out source code to the configured `path` (defaults to the `working_directory`). The reason this is a special step is because it is more of a helper function designed to make checking out code easy for you. If you require doing git over HTTPS you should not use this step as it configures git to checkout over ssh