### PR TITLE
update integration tests and add integraion-test cargo config 

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,3 +2,4 @@
 wasm = "build --release --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 schema = "run --bin schema"
+integration-test = "test --lib integration_tests"

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -2,6 +2,7 @@
 mod tests {
     use crate::helpers::CwTemplateContract;
     use crate::msg::InstantiateMsg;
+    use cosmwasm_std::testing::MockApi;
     use cosmwasm_std::{Addr, Coin, Empty, Uint128};
     use cw_multi_test::{App, AppBuilder, Contract, ContractWrapper, Executor};
 
@@ -24,7 +25,7 @@ mod tests {
                 .bank
                 .init_balance(
                     storage,
-                    &Addr::unchecked(USER),
+                    &MockApi::default().addr_make(USER),
                     vec![Coin {
                         denom: NATIVE_DENOM.to_string(),
                         amount: Uint128::new(1),
@@ -37,6 +38,12 @@ mod tests {
     fn proper_instantiate() -> (App, CwTemplateContract) {
         let mut app = mock_app();
         let cw_template_id = app.store_code(contract_template());
+
+        let user = app.api().addr_make(USER);
+        assert_eq!(
+            app.wrap().query_balance(user, NATIVE_DENOM).unwrap().amount,
+            Uint128::new(1)
+        );
 
         let msg = InstantiateMsg { count: 1i32 };
         let cw_template_contract_addr = app


### PR DESCRIPTION
I made these changes because of an issue with `query_balance()` using cw_template. 

When you try to get the balance of `USER` in the current code:

```rust
 const USER: &str = "USER";
 dbg!(app.wrap().query_balance(USER, NATIVE_DENOM).unwrap());
```

It results in this error: 
```
error: value: GenericErr { msg: "Querier contract error: Generic error: Error decoding bech32", backtrace: <disabled> }
```

When I searched for the error online, it led me to this article: https://medium.com/cosmwasm/addresses-in-cosmwasm-multitest-68207ae845e6 and with it I was able to find a solution which is:

```rust
  const USER: &str = "USER";
  let user = app.api().addr_make(USER)
  dbg!(app.wrap().query_balance(user, NATIVE_DENOM).unwrap());
  ```

This all seemed like extra code that could confuse people, so I added `&MockApi::default().addr_make(USER)` to `mock_app()` and added an assert to confirm the address has the coin in `proper_instantiate()` with:
```rust
    let user = app.api().addr_make(USER);
    assert_eq!(
      app.wrap().query_balance(user, NATIVE_DENOM).unwrap().amount,
      Uint128::new(1)
      );
``` 

This addition might not seem necessary but I think it's important because it shows users of this template how to `query_balance()` in their integration test which they will eventually do. Right now there aren't a lot of resources out there that will show them how to fix the `Generic error: Error decoding bech32` error.

The second thing I changed was the `config` file in `.cargo`. I added a config for integration tests so users of the template could easily run `cargo integration-test` to run their integration tests.


