### PR TITLE
Update optimizer version to 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ library = []
 optimize = """docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/optimizer:0.15.0
+  cosmwasm/optimizer:0.16.0
 """
 
 [dependencies]

--- a/Developing.md
+++ b/Developing.md
@@ -74,7 +74,7 @@ to run it is this:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/optimizer:0.15.0
+  cosmwasm/optimizer:0.16.0
 ```
 
 Or, If you're on an arm64 machine, you should use a docker image built with arm64.
@@ -83,7 +83,7 @@ Or, If you're on an arm64 machine, you should use a docker image built with arm6
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/optimizer-arm64:0.15.0
+  cosmwasm/optimizer-arm64:0.16.0
 ```
 
 We must mount the contract code to `/code`. You can use an absolute path instead

--- a/meta/appveyor.yml
+++ b/meta/appveyor.yml
@@ -10,7 +10,7 @@
 image: Ubuntu
 
 environment:
-  TOOLCHAIN: 1.74.0
+  TOOLCHAIN: 1.75.0
   CARGO_GENERATE_VERSION: 0.18.3
 
 # services:


### PR DESCRIPTION
Preparing the Wasm bytecode using Docker with optimizer 15 gave me the following error:
`error: package `derive_more v1.0.0` cannot be built because it requires rustc 1.75.0 or newer, while the currently active rustc version is 1.73.0`.
Upgrading to cosmwasm/optimizer:0.16.0 fixes the issue.